### PR TITLE
Verification logic

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -27,7 +27,7 @@
 
   <style>
   header {
-    background-image: url('http://img13.deviantart.net/2c69/i/2014/022/b/d/league_of_legends_wallpaper_by_su_ke-d73cjhw.jpg');
+    background-image: url('http://orig13.deviantart.net/7009/f/2014/022/6/7/league_of_legends_wallpaper_by_su_ke-d73cjhw.jpg');
   }
   nav a {
     cursor: pointer;

--- a/client/js/components/header/app-header.js
+++ b/client/js/components/header/app-header.js
@@ -19,7 +19,7 @@ var Header = React.createClass({
       displayName: "",
       teams: []
       //dummy data below
-      //teams: [{id: 1, teamName: "pew pew"}, {id:2, teamName: "win factory"}, {id:3, teamName: "scrub life"}]
+      // teams: [{id: 1, teamName: "pew pew"}, {id:2, teamName: "win factory"}, {id:3, teamName: "scrub life"}]
     }
   },
 
@@ -27,8 +27,8 @@ var Header = React.createClass({
     $.get('/profile', function(result){
       if(this.isMounted()){
         this.setState({
-          displayName: result.displayName,
-          teams: result.teams
+          displayName: result.displayName
+          // teams: result.teams
         })
       }
     }.bind(this));

--- a/client/js/components/user-profile/settings.js
+++ b/client/js/components/user-profile/settings.js
@@ -1,7 +1,23 @@
 var React = require('react');
 var Router = require('react-router');
 
+var leagueAccount;
+
+var leagueUpdate = function(){
+  if(true){
+    leagueAccount = <form>
+      <span>True</span>
+    </form>;
+  } else {
+    this.leagueAccount = <form>
+      <span>False</span>
+    </form>;
+  }
+}
+
 var Settings = React.createClass({
+
+  regionList: ['NA', 'KR', 'EUNE', 'EUW', 'BR', 'RU', 'LAN', 'LAS', 'OCE', 'PBE', 'TR'],
 
   getInitialState: function(){
     return {
@@ -17,6 +33,7 @@ var Settings = React.createClass({
           displayName: result.displayName
         })
       }
+      leagueUpdate();
     }.bind(this));
   },
 
@@ -28,6 +45,22 @@ var Settings = React.createClass({
 
   render: function(){
     return(
+      <form className="form-horizontal" method="POST" action="">
+        <div className="form-group">
+          <label className="col-sm-2 control-label">Summoner Name</label>
+          <div className="col-sm-8">
+            <input type="text" className="form-control" name="displayName" value={this.state.displayName} onChange={this.handleChange} />
+          </div>
+          <div className="col-sm-2">
+            <select>
+              {this.regionList.map(function(val){return <option value={val.toLowerCase()}>{val}</option>})}
+            </select>
+          </div>
+        </div>
+      </form>
+
+      <div></div>
+
       <form className="form-horizontal" method="POST" action="/settings">
         <div className="form-group">
           <label className="col-sm-2 control-label">Display Name</label>

--- a/client/js/components/user-profile/settings.js
+++ b/client/js/components/user-profile/settings.js
@@ -17,8 +17,6 @@ var leagueUpdate = function(){
 
 var Settings = React.createClass({
 
-  regionList: ['NA', 'KR', 'EUNE', 'EUW', 'BR', 'RU', 'LAN', 'LAS', 'OCE', 'PBE', 'TR'],
-
   getInitialState: function(){
     return {
       displayName: ""
@@ -45,22 +43,6 @@ var Settings = React.createClass({
 
   render: function(){
     return(
-      <form className="form-horizontal" method="POST" action="">
-        <div className="form-group">
-          <label className="col-sm-2 control-label">Summoner Name</label>
-          <div className="col-sm-8">
-            <input type="text" className="form-control" name="displayName" value={this.state.displayName} onChange={this.handleChange} />
-          </div>
-          <div className="col-sm-2">
-            <select>
-              {this.regionList.map(function(val){return <option value={val.toLowerCase()}>{val}</option>})}
-            </select>
-          </div>
-        </div>
-      </form>
-
-      <div></div>
-
       <form className="form-horizontal" method="POST" action="/settings">
         <div className="form-group">
           <label className="col-sm-2 control-label">Display Name</label>

--- a/server/controllers/user.controller.js
+++ b/server/controllers/user.controller.js
@@ -3,6 +3,7 @@ var passport = require( 'passport' );
 var bcrypt = require('bcryptjs');
 var request = require('request');
 var config = require('../config/config');
+var gen = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
 
 module.exports = {
 
@@ -37,12 +38,12 @@ module.exports = {
     })
   },
 
-getAllProfiles: function( req, res, next ){
+  getAllProfiles: function( req, res, next ){
     User.findAll()
-       .then(function (teamProfiles) {
-         res.json(teamProfiles)
-     })
-   },
+    .then(function (teamProfiles) {
+      res.json(teamProfiles)
+    })
+  },
 
   getOwnProfile: function(req, res){ // Retrieves own profile data
     User.findById(req.session.passport.user)
@@ -63,7 +64,7 @@ getAllProfiles: function( req, res, next ){
     });
   },
 
-  updateSettings: function(req, res){ // Updates important data
+  updateSettings: function(req, res){ // Updates account data
     User.findById(req.session.passport.user)
     .then(function(data){
       User.update({displayName: req.body.displayName}, {where: {id: req.session.passport.user}});
@@ -71,9 +72,67 @@ getAllProfiles: function( req, res, next ){
     })
   },
 
-  updateRatings: function(req, res){    
+  setSummoner: function(req, res){
+    var key = "", obj = {}, region = req.body.region.toLowerCase(), name = req.body.name.toLowerCase().replace(' ', '');
+    for(var i = 0; i < 20; i++){
+      key += gen.charAt(Math.floor(Math.random()*62));
+    }
+    relay('https://' + region + '.api.pvp.net/api/lol/' + region + '/v1.4/summoner/by-name/' + name + '?api_key=' + config.lolapi, function(er, data) {
+      obj.id = JSON.parse(data)[name].id;
+      obj.name = JSON.parse(data)[name].name;
+      obj.level = JSON.parse(data)[name].summonerLevel;
+      obj.avatar = 'avatar.leagueoflegends.com/' + region + '/' + name + '.png';
+      obj.region = req.body.region;
+      obj.verified = false;
+      obj.verifyKey = key;
+      obj.verifyRoute = "https://" + obj.region + ".api.pvp.net/api/lol/" + obj.region + "/v1.4/summoner/" + obj.id + "/runes?api_key=" + config.lolapi;
+      User.update({games: obj}, {where: {id: req.session.passport.user}})
+      .then(function(){
+        res.redirect('/#/settings');
+      })
+    })
+  },
+
+  verifySummoner: function(req, res){
     User.findById(req.session.passport.user)
-    .then(function(data){      
+    .then(function(data){
+      var obj = data.games;
+      relay(obj.verifyRoute, function(err, body){
+        if(err) throw err;
+        if(JSON.parse(body)[obj.id].pages[0].name === obj.verifyKey){
+          obj.verified = true;
+          obj.verifyKey = false;
+          obj.verifyRoute = false;
+          User.update({games: obj}, {where: {id: req.session.passport.user}})
+          .then(function(){
+            res.redirect('/#/profile');
+          });
+        } else {
+          res.send("Verification failed. Check to see that the name of your first rune page is: " + obj.verifyKey);
+        }
+      })
+    })
+  },
+
+  updateSummoner: function(req, res){ // Updates game data
+    var user;
+    User.findById(req.session.passport.user)
+    .then(function(info){
+      user = info.games;
+      relay('https://' + user.region + '.api.pvp.net/api/lol/' + user.region + '/v1.4/summoner/' + user.id + '?api_key=' + config.lolapi, function(er, data) {
+        user.name = JSON.parse(data)[user.id].name;
+        user.level = JSON.parse(data)[user.id].summonerLevel;
+        User.update({games: user}, {where: {id: req.session.passport.user}})
+        .then(function(){
+          res.redirect('/#/profile');
+        })
+      })
+    })
+  },
+
+  updateRatings: function(req, res){ // Updates ratings data
+    User.findById(req.session.passport.user)
+    .then(function(data){
       User.update({
         ratings: req.body.ratings,
         counter: req.body.counter,
@@ -115,6 +174,7 @@ getAllProfiles: function( req, res, next ){
       obj.name = JSON.parse(data)[username].name;
       obj.level = JSON.parse(data)[username].summonerLevel;
       obj.avatar = 'avatar.leagueoflegends.com/' + region + '/' + username + '.png';
+      obj.region = region;
       //second api call
       request('https://' + region + '.api.pvp.net/api/lol/' + region + '/v2.5/league/by-summoner/' + obj.id + '?api_key=' + config.lolapi, function(err, stat, body) {
         if(err) { throw err }
@@ -133,6 +193,8 @@ getAllProfiles: function( req, res, next ){
 
 
 
+
+
 };
 
 function relay(url, callback) {
@@ -141,6 +203,7 @@ function relay(url, callback) {
       callback(err, null);
     } else if(stat.statusCode < 200 || stat.statusCode >= 400) {
       console.log("Status Code: " + stat.statusCode);
+      res.send("It appears someone at Riot tripped over the power cord. Please try again soon =p");
     } else {
       callback(null, body);
     }

--- a/server/routes/user.routes.js
+++ b/server/routes/user.routes.js
@@ -27,7 +27,7 @@ module.exports = function(app) {
     User.getAllProfiles(req, res);
   } );
 
-  app.get('/profile', function(req, res){ // Profile data from bio
+  app.get('/profile', function(req, res){ // Personal account data
     User.getOwnProfile(req, res);
   });
 
@@ -35,12 +35,24 @@ module.exports = function(app) {
     User.updateBio(req, res);
   });
 
-  app.post('/ratings', function(req, res){ // Update bio data
+  app.post('/ratings', function(req, res){ // Update ratings
     User.updateRatings(req, res);
   });
 
-  app.post('/settings', function(req, res){
+  app.post('/settings', function(req, res){ // Update account information
     User.updateSettings(req, res);
+  });
+
+  app.post('/setSummoner', function(req, res){ // Update summoner information
+    User.setSummoner(req, res);
+  });
+
+  app.post('/verifySummoner', function(req, res){
+    User.verifySummoner(req, res);
+  });
+
+  app.post('/updateSummoner', function(req, res){
+    User.updateSummoner(req, res);
   });
 
   app.get(/\/username\/.*/, function(req, res){ // Fetches a user by displayName, case sensitive!
@@ -61,4 +73,6 @@ module.exports = function(app) {
       User.lolapi(req, res, req.url.split('/')[2], req.url.split('/')[3].slice(0, -5));
     }
   });
+
+
 };


### PR DESCRIPTION
This PR contains the logic for persisting basic summoner info, verifying it against the player's rune page, and updating their information from there.
- `/setSummoner` requires a "name" and "region" that map to the player's summoner name and region code, respectively and persists the new account to the database while generating a pseudo-random key for them to use
- `/verifySummoner` will check the name of their first rune page against the key that was generated by the previous route and, if they match, will set the profile's verified status to true and remove the key
- `/updateSummoner` will check for changes to the summoner's name / level and update them - this can be bound to a button to prevent unnecessary api calls to values that are infrequently updated (names don't change often for most, levels cap at 30)

As a minor change, a higher resolution landing image has been incorporated which should smooth out the appearance of the landing page on larger screens. It is likely going to need to be multi-sized for different displays and rendered smartly with css to prevent the large file size from impacting mobile devices/tablets.
